### PR TITLE
Add tests for forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /requirements.txt
 /test_requirements.txt
 __pycache__
+/.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,36 @@
 language: python
+
+# Matrix of build options
 python:
-- '3.4'
-- '3.5'
+  - '3.4'
+  - '3.5'
+
+env:
+  global:
+    - DJANGO_SETTINGS_MODULE="tests.settings"
+    - TOX_ENV=
+  matrix:
+    - DJANGO='1.9'
+    - DJANGO='1.10'
+
+matrix:
+  include:
+    - env: TOX_ENV=style
+      python: '3.5'
+
 install:
-- pip install -e . -r requirements.in -r test_requirements.in
+  - pip install --upgrade pip wheel tox
+
 cache:
   directories:
-  - $HOME/virtualenv
-env:
- - DJANGO_SETTINGS_MODULE=tests.settings
+    - $HOME/.cache/pip
+    - $HOME/virtualenv
+
 script:
-- pep8 .
-- isort --recursive --check-only --diff postgres_composite_types tests
-- pylint postgres_composite_types tests
-- django-admin.py test
+  # Run tox using either a specific environment from TOX_ENV,
+  # or building one from the environment variables
+  - tox -e "${TOX_ENV:-py${TRAVIS_PYTHON_VERSION/./}-dj${DJANGO}}"
+
 sudo: false
 deploy:
   provider: pypi

--- a/postgres_composite_types/__init__.py
+++ b/postgres_composite_types/__init__.py
@@ -116,10 +116,6 @@ class BaseField(models.Field):
         defaults = {
             'form_class': CompositeTypeField,
             'model': self.Meta.model,
-            'fields': [
-                (name, field.formfield())
-                for name, field in self.Meta.fields
-            ],
         }
         defaults.update(kwargs)
 

--- a/postgres_composite_types/__init__.py
+++ b/postgres_composite_types/__init__.py
@@ -188,11 +188,15 @@ class CompositeTypeMeta(type):
                 fields.append((field_name, field))
 
         # retrieve the Meta from our declaration
-        meta_obj = attrs.pop('Meta', object())
+        try:
+            meta_obj = attrs.pop('Meta')
+        except KeyError:
+            raise TypeError('%s has no "Meta" class' % (name,))
+
         try:
             meta_obj.db_type
         except AttributeError:
-            raise TypeError("Meta.db_type is required.")
+            raise TypeError("%s.Meta.db_type is required." % (name,))
 
         meta_obj.fields = fields
 

--- a/postgres_composite_types/__init__.py
+++ b/postgres_composite_types/__init__.py
@@ -303,6 +303,16 @@ class CompositeType(object, metaclass=CompositeTypeMeta):
             for name, field in self._meta.fields
         )
 
+    def __eq__(self, other):
+        if not isinstance(other, CompositeType):
+            return False
+        if self._meta.model != other._meta.model:
+            return False
+        for name, _ in self._meta.fields:
+            if getattr(self, name) != getattr(other, name):
+                return False
+        return True
+
     class Field(BaseField):
         """
         Placeholder for the field that will be produced for this type.

--- a/postgres_composite_types/compat.py
+++ b/postgres_composite_types/compat.py
@@ -1,0 +1,44 @@
+"""
+Compatibility shims and future imports for supporting multiple versions of
+Django.
+"""
+import django
+
+# Importing things in the 'wrong' version of Django makes pylint complain
+# pylint:disable=no-name-in-module,import-error
+# Importing things in an if: makes pylint complain
+# pylint:disable=wrong-import-position
+
+__all__ = ['prefix_validation_error']
+
+if django.VERSION >= (1, 10):
+    from django.contrib.postgres.utils import prefix_validation_error
+else:
+    from django.core.exceptions import ValidationError
+    from django.utils.functional import SimpleLazyObject
+    from django.utils.translation import string_concat
+
+    def prefix_validation_error(error, prefix, code, params):
+        """
+        Prefix a validation error message while maintaining the existing
+        validation data structure.
+        """
+        if error.error_list == [error]:
+            error_params = error.params or {}
+            return ValidationError(
+                # We can't simply concatenate messages since they might require
+                # their associated parameters to be expressed correctly which
+                # is not something `string_concat` does. For example, proxied
+                # ungettext calls require a count parameter and are converted
+                # to an empty string if they are missing it.
+                message=string_concat(
+                    SimpleLazyObject(lambda: prefix % params),
+                    SimpleLazyObject(lambda: error.message % error_params),
+                ),
+                code=code,
+                params=dict(error_params, **params),
+            )
+        return ValidationError([
+            prefix_validation_error(e, prefix, code, params)
+            for e in error.error_list
+        ])

--- a/postgres_composite_types/forms.py
+++ b/postgres_composite_types/forms.py
@@ -83,7 +83,14 @@ class CompositeTypeField(forms.Field):
     """
 
     def __init__(self, *args, fields=None, model=None, **kwargs):
-        fields = OrderedDict(fields)
+        if fields is None:
+            fields = OrderedDict([
+                (name, field.formfield())
+                for name, field in model._meta.fields
+            ])
+        else:
+            fields = OrderedDict(fields)
+
         widget = CompositeTypeWidget(widgets=[
             (name, field.widget)
             for name, field in fields.items()

--- a/postgres_composite_types/forms.py
+++ b/postgres_composite_types/forms.py
@@ -38,8 +38,10 @@ from collections import OrderedDict
 
 from django import forms
 from django.utils.safestring import mark_safe
+from django.utils.translation import ugettext as _
 
 from . import CompositeType
+from .compat import prefix_validation_error
 
 LOGGER = logging.getLogger(__name__)
 
@@ -82,6 +84,10 @@ class CompositeTypeField(forms.Field):
     Takes an ordered dict of fields to produce a composite form field
     """
 
+    default_error_messags = {
+        'field_invalid': _('%s: '),
+    }
+
     def __init__(self, *args, fields=None, model=None, **kwargs):
         if fields is None:
             fields = OrderedDict([
@@ -119,10 +125,19 @@ class CompositeTypeField(forms.Field):
                 value = None
 
         else:
-            value = self.model(**{
-                name: field.clean(value.get(name))
-                for name, field in self.fields.items()
-            })
+            cleaned_data = {}
+            errors = []
+
+            for name, field in self.fields.items():
+                try:
+                    cleaned_data[name] = field.clean(value.get(name))
+                except forms.ValidationError as error:
+                    errors.append(prefix_validation_error(
+                        error, code='field_invalid',
+                        prefix='%(label)s: ', params={'label': field.label}))
+            if errors:
+                raise forms.ValidationError(errors)
+            value = self.model(**cleaned_data)
 
         LOGGER.debug("clean: < %s", value)
 

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,11 @@
 Setup.py
 """
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 if __name__ == '__main__':
     with \
             open('requirements.in') as requirements, \
-            open('test_requirements.in') as test_requirements, \
             open('README.md') as readme:
         setup(
             use_scm_version=True,
@@ -33,5 +32,4 @@ if __name__ == '__main__':
             install_requires=requirements.readlines(),
 
             test_suite='tests',
-            tests_require=test_requirements.readlines(),
         )

--- a/test_requirements.in
+++ b/test_requirements.in
@@ -1,5 +1,5 @@
 nose
-django-nose
+-egit+https://github.com/django-nose/django-nose.git@master#egg=django-nose
 django_fake_model
 
 pep8

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,24 @@
+from django.db import models
+from django_fake_model.models import FakeModel
+
+from postgres_composite_types import CompositeType
+
+
+class SimpleType(CompositeType):
+    """A test type."""
+    class Meta:
+        db_type = 'test_type'
+
+    # pylint:disable=invalid-name
+    a = models.IntegerField(verbose_name='A number')
+    b = models.CharField(verbose_name='A name', max_length=32)
+    c = models.DateTimeField(verbose_name='A date')
+
+
+class SimpleModel(FakeModel):
+    """A test model."""
+    # pylint:disable=invalid-name
+    test_field = SimpleType.Field()
+
+    class Meta:
+        app_label = 'test'

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,3 +1,4 @@
+"""Models and types for the tests"""
 from django.db import models
 from django_fake_model.models import FakeModel
 

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -5,7 +5,7 @@ Migration to create custom types
 
 from django.db import migrations
 
-from ..test_field import TestType
+from ..base import SimpleType
 
 
 class Migration(migrations.Migration):
@@ -15,5 +15,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        TestType.Operation(),
+        SimpleType.Operation(),
     ]

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -3,12 +3,11 @@
 import datetime
 from unittest import mock
 
-from django.db import connection, models
+from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
 from django.test import TestCase, TransactionTestCase
-from django_fake_model.models import FakeModel
 
-from postgres_composite_types import CompositeType, composite_type_created
+from postgres_composite_types import composite_type_created
 
 from .base import SimpleModel, SimpleType
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,0 +1,151 @@
+"""Tests for CompositeTypeField and CompositeTypeWidget."""
+import datetime
+
+from django import forms
+from django.test import SimpleTestCase
+
+from postgres_composite_types.forms import CompositeTypeField
+
+from .test_field import SimpleType
+
+
+class TestField(SimpleTestCase):
+    """
+    Test the CompositeTypeField
+    """
+
+    class SimpleForm(forms.Form):
+        """Test form with CompositeTypeField"""
+        simple_field = CompositeTypeField(model=SimpleType)
+
+    simple_valid_data = {
+        'simple_field-a': '1',
+        'simple_field-b': 'foo',
+        'simple_field-c': '2016-05-24 17:38:32',
+    }
+
+    def test_composite_field(self):
+        """Test that a composite field can create an instance of its model"""
+
+        form = self.SimpleForm(data=self.simple_valid_data)
+
+        self.assertTrue(form.is_valid())
+
+        out = form.cleaned_data['simple_field']
+        self.assertIsInstance(out, SimpleType)
+        self.assertEqual(out, SimpleType(
+            a=1, b='foo', c=datetime.datetime(2016, 5, 24, 17, 38, 32)))
+
+    def test_validation(self):
+        """
+        Test that a composite field validates its input, throwing errors for
+        bad data
+        """
+        form = self.SimpleForm(data={
+            'simple_field-a': 'one',
+            'simple_field-b': '',
+            'simple_field-c': 'yesterday, 10 oclock',
+        })
+        # CompositeTypeFields should fail validation if any of their fields
+        # fail validation
+        self.assertFalse(form.is_valid())
+        self.assertIn('simple_field', form.errors)
+        # All three fields should be incorrect
+        self.assertEqual(len(form.errors['simple_field']), 3)
+        # Errors should be formatted like 'Label: Error message'
+        self.assertEqual(str(form.errors['simple_field'][0]),
+                         'A number: Enter a whole number.')
+
+    def test_subfield_validation(self):
+        """Errors on subfields should be accessible"""
+        form = self.SimpleForm(data={
+            'simple_field-a': 'one',
+        })
+        self.assertFalse(form.is_valid())
+        self.assertEqual(str(form['simple_field']['a'].errors[0]),
+                         'Enter a whole number.')
+
+    def test_subfields(self):
+        """Test accessing bound subfields"""
+        form = self.SimpleForm(data=self.simple_valid_data)
+        a_bound_field = form['simple_field']['a']
+
+        self.assertIsInstance(a_bound_field.field, forms.IntegerField)
+        self.assertEqual(a_bound_field.html_name, 'simple_field-a')
+
+    def test_nested_prefix(self):
+        """Test forms with a prefix"""
+        form = self.SimpleForm(data=self.simple_valid_data, prefix='step1')
+
+        composite_bound_field = form['simple_field']
+        self.assertEqual(composite_bound_field.html_name,
+                         'step1-simple_field')
+
+        a_bound_field = composite_bound_field['a']
+        self.assertEqual(a_bound_field.html_name,
+                         'step1-simple_field-a')
+
+
+class OptionalFieldTests(SimpleTestCase):
+    """
+    CompundTypeFields should handle being optional sensibly
+    """
+    class OptionalSimpleForm(forms.Form):
+        """Test form with optional CompositeTypeField"""
+        optional_field = CompositeTypeField(model=SimpleType, required=False)
+
+    simple_valid_data = {
+        'optional_field-a': '1',
+        'optional_field-b': 'foo',
+        'optional_field-c': '2016-05-24 17:38:32',
+    }
+
+    def test_blank_fields(self):
+        """Test leaving all the fields blank"""
+
+        form = self.OptionalSimpleForm(data={
+            'simple_field-a': '',
+            'simple_field-b': '',
+            'simple_field-c': '',
+        })
+
+        # The form should be valid, but simple_field should be None
+        self.assertTrue(form.is_valid())
+        self.assertIsNone(form.cleaned_data['optional_field'])
+
+    def test_missing_fields(self):
+        """Test not even submitting the fields"""
+
+        form = self.OptionalSimpleForm(data={})
+
+        # The form should be valid, but simple_field should be None
+        self.assertTrue(form.is_valid())
+        self.assertIsNone(form.cleaned_data['optional_field'])
+
+    def test_filling_out_fields(self):
+        """Test filling out the fields normally still works"""
+
+        form = self.OptionalSimpleForm(data=self.simple_valid_data)
+
+        self.assertTrue(form.is_valid())
+        out = form.cleaned_data['optional_field']
+        self.assertIsInstance(out, SimpleType)
+        self.assertEqual(out, SimpleType(
+            a=1, b='foo', c=datetime.datetime(2016, 5, 24, 17, 38, 32)))
+
+    def test_some_valid_some_empty(self):
+        """Test with some fields filled in, some required fields blank"""
+
+        form = self.OptionalSimpleForm(data={
+            'optional_field-a': '1',
+            'optional_field-b': 'foo',
+            'optional_field-c': '',
+        })
+
+        self.assertFalse(form.is_valid())
+        self.assertIn('optional_field', form.errors)
+        # Only the one field should fail validation
+        self.assertEqual(len(form.errors['optional_field']), 1)
+        # Errors should be formatted like 'Label: Error message'
+        self.assertEqual('A date: This field is required.',
+                         str(form.errors['optional_field'][0]))

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,23 @@
+[tox]
+skipsdist = True
+envlist =
+  py{34,35}-dj{1.9,1.10}
+  style
+
+[testenv]
+usedevelop = True
+setenv =
+  DJANGO_SETTINGS_MODULE=tests.settings
+commands =
+  django-admin test
+
+deps =
+  -rtest_requirements.in
+  dj1.9: Django>=1.9,<1.10
+  dj1.10: Django==1.10a1
+
+[testenv:style]
+commands =
+  pep8 postgres_composite_types tests
+  isort --recursive --check-only --diff postgres_composite_types tests
+  pylint postgres_composite_types tests


### PR DESCRIPTION
Tests for the CompositeTypeField have been added. Tests for the CompositeTypeWidget are not included in this PR.

A few changes were made along the way, to make the forms API nicer and to support testing:

* `CompositeTypeField.__init__` generates fields from a CompositeType, instead of `BaseField.formfield`. This makes using `CompositeTypeField`s much easier, as developers only have to supply a model, and everything else will be done for them.

* `CompositeType.__eq__` has been added. It compares things field-by-field. Required for the tests, but also a good idea to have.

* Nose was being annoying again, trying to run the tests on TestModel / TestType, and getting most upset when this did not behave as expected. They have been renamed to SimpleModel and SimpleType.

* Having a `CompositeType` without a `Meta` made no sense, as `Meta.db_field` is required. Better error messages have been added for the case of a missing `CompositeType.Meta` class. This is unrelated to adding tests for forms, but I came across the error because of Nose and TestModel / TestType naming. This helped me debug and will probably help others as well.

* When cleaning a CompositeTypeField, each subfield is cleaned, and any `ValidationError`s caught. Any errors are then raised as a group. Previously, only the error from the first invalid subfield was raised.