### PR TITLE
Convert types to/from database using Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Authors
 -------
 
 * Danielle Madeley <danielle@madeley.id.au>
+* Tim Heap <hello@timheap.me>
 
 License
 -------

--- a/postgres_composite_types/__init__.py
+++ b/postgres_composite_types/__init__.py
@@ -37,13 +37,13 @@ Takes inspiration from:
 import logging
 from collections import OrderedDict
 
-from django.db import connections, migrations, models
+from django.db import migrations, models
 from django.db.backends.postgresql.base import \
     DatabaseWrapper as PostgresDatabaseWrapper
 from django.db.backends.signals import connection_created
 from django.dispatch import Signal
 from psycopg2 import ProgrammingError
-from psycopg2.extensions import AsIs, ISQLQuote, adapt, register_adapter
+from psycopg2.extensions import ISQLQuote, adapt, register_adapter
 from psycopg2.extras import CompositeCaster, register_composite
 
 LOGGER = logging.getLogger(__name__)
@@ -121,7 +121,7 @@ class BaseField(models.Field):
 
     def formfield(self, **kwargs):
         """Form field for address."""
-        from .forms import CompositeTypeField, CompositeTypeWidget
+        from .forms import CompositeTypeField
 
         defaults = {
             'form_class': CompositeTypeField,

--- a/postgres_composite_types/__init__.py
+++ b/postgres_composite_types/__init__.py
@@ -68,7 +68,12 @@ class QuotedCompositeType(object):
             for _, field in self.model._meta.fields]
 
     def __conform__(self, protocol):
-        # Required for nested composite types
+        """
+        QuotedCompositeType conform to the ISQLQuote protocol all by
+        themselves. This is required for nested composite types.
+
+        Returns None if it can not conform to the requested protocol.
+        """
         if protocol is ISQLQuote:
             return self
 
@@ -92,9 +97,9 @@ class QuotedCompositeType(object):
         Returns something like ``b"(value1, value2)::type_name"``
         """
         if self.prepared_value is None:
-            raise RuntimeError(
-                "%(name)s.prepare() must be called before %(name)s.getquoted()"
-                % {'name': type(self).__name__})
+            raise RuntimeError("{name}.prepare() must be called before "
+                               "{name}.getquoted()".format(
+                                   name=type(self).__name__))
 
         db_type = self.model._meta.db_type.encode('ascii')
         return self.prepared_value.getquoted() + b'::' + db_type
@@ -352,6 +357,13 @@ class CompositeType(object, metaclass=CompositeTypeMeta):
             register_adapter(cls, QuotedCompositeType)
 
     def __conform__(self, protocol):
+        """
+        CompositeTypes know how to conform to the ISQLQuote protocol, by
+        wrapping themselves in a QuotedCompositeType. The ISQLQuote protocol
+        is all about formatting custom types for use in SQL statements.
+
+        Returns None if it can not conform to the requested protocol.
+        """
         if protocol is ISQLQuote:
             return QuotedCompositeType(self)
 

--- a/postgres_composite_types/__init__.py
+++ b/postgres_composite_types/__init__.py
@@ -43,11 +43,61 @@ from django.db.backends.postgresql.base import \
 from django.db.backends.signals import connection_created
 from django.dispatch import Signal
 from psycopg2 import ProgrammingError
-from psycopg2.extras import register_composite
+from psycopg2.extensions import AsIs, ISQLQuote, adapt, register_adapter
+from psycopg2.extras import CompositeCaster, register_composite
 
 LOGGER = logging.getLogger(__name__)
 
 __all__ = ['CompositeType']
+
+
+class QuotedCompositeType(object):
+    """
+    A wrapper for CompositeTypes that knows how to convert itself into a safe
+    postgres representation. Created from CompositeType.__conform__
+    """
+    prepared_value = None
+
+    def __init__(self, obj):
+        self.obj = obj
+        self.model = obj._meta.model
+
+        self.values = [
+            adapt(field.get_db_prep_value(field.value_from_object(self.obj),
+                                          self.model.registered_connection))
+            for _, field in self.model._meta.fields]
+
+    def __conform__(self, protocol):
+        # Required for nested composite types
+        if protocol is ISQLQuote:
+            return self
+
+    def prepare(self, connection):
+        """
+        Prepare anything that depends on the database connection, such as
+        strings with encodings.
+        """
+        for value in self.values:
+            if hasattr(value, 'prepare'):
+                value.prepare(connection)
+
+        self.prepared_value = adapt(tuple(self.values))
+        self.prepared_value.prepare(connection)
+
+    def getquoted(self):
+        """
+        Format composite types as the correct Postgres snippet, including
+        casts, for queries.
+
+        Returns something like ``b"(value1, value2)::type_name"``
+        """
+        if self.prepared_value is None:
+            raise RuntimeError(
+                "%(name)s.prepare() must be called before %(name)s.getquoted()"
+                % {'name': type(self).__name__})
+
+        db_type = self.model._meta.db_type.encode('ascii')
+        return self.prepared_value.getquoted() + b'::' + db_type
 
 
 class BaseField(models.Field):
@@ -63,51 +113,6 @@ class BaseField(models.Field):
                                "for postgres")
 
         return self.Meta.db_type
-
-    def to_python(self, value):
-        LOGGER.debug("to_python: > %s", value)
-
-        if isinstance(value, dict):
-            value = self.Meta.model(**value)
-        else:
-            pass
-
-        LOGGER.debug("to_python: < %s", value)
-
-        return value
-
-    def from_db_value(self, value, expression, connection, context):
-        """Convert the DB value into a Python type."""
-        LOGGER.debug("from_db_value: > %s (%s)", value, type(value))
-
-        if isinstance(value, tuple):
-            value = self.Meta.model(*value)
-        else:
-            pass
-
-        LOGGER.debug("from_db_value: < %s (%s)", value, type(value))
-
-        return value
-
-    def get_prep_value(self, value):
-        LOGGER.debug("get_prep_value: > %s (%s)",
-                     value, type(value))
-
-        if isinstance(value, dict):
-            # Handle dicts because why not?
-            value = tuple(
-                field.get_prep_value(value.get(name))
-                for name, field in self.Meta.fields
-            )
-        elif isinstance(value, self.Meta.model):
-            value = value.__to_tuple__()
-        else:
-            pass
-
-        LOGGER.debug("get_prep_value: < %s (%s)",
-                     value, type(value))
-
-        return value
 
     def formfield(self, **kwargs):
         """Form field for address."""
@@ -156,6 +161,17 @@ class BaseOperation(migrations.operations.base.Operation):
     def database_backwards(self, app_label, schema_editor,
                            from_state, to_state):
         schema_editor.execute('DROP TYPE %s' % self.Meta.db_type)
+
+
+class BaseCaster(CompositeCaster):
+    """
+    Base caster to transform a tuple of values from postgres to a model
+    instance.
+    """
+    Meta = None
+
+    def make(self, values):
+        return self.Meta.model(*values)
 
 
 class CompositeTypeMeta(type):
@@ -210,6 +226,11 @@ class CompositeTypeMeta(type):
                                   (BaseOperation,),
                                   {'Meta': meta_obj})
 
+        # create the caster for this type
+        attrs['Caster'] = type('%sCaster' % name,
+                               (BaseCaster,),
+                               {'Meta': meta_obj})
+
         new_cls = super().__new__(mcs, name, bases, attrs)
         new_cls._meta = meta_obj
 
@@ -241,25 +262,13 @@ class CompositeTypeMeta(type):
             except ProgrammingError:
                 LOGGER.warning(
                     "Failed to register composite %s. This might be because "
-                    "the migration to register it has not run yet")
+                    "the migration to register it has not run yet",
+                    cls.__name__)
 
         # Disconnect the signal now - only need to register types on the
         # initial connection
         connection_created.disconnect(cls.database_connected,
                                       dispatch_uid=cls._meta.db_type)
-
-    def register_composite(cls, connection):
-        """
-        Register this CompositeType with Postgres.
-
-        If the CompositeType does not yet exist in the database, this will
-        fail.  Hopefully a migration will come along shortly and create the
-        type in the database. If `retry` is True, this CompositeType will try
-        to register itself again after the type is created.
-        """
-
-        with connection.temporary_connection() as cur:
-            register_composite(cls._meta.db_type, cur, globally=True)
 
 
 # pylint:disable=invalid-name
@@ -273,6 +282,9 @@ class CompositeType(object, metaclass=CompositeTypeMeta):
     """
 
     _meta = None
+
+    # The database connection this type is registered with
+    registered_connection = None
 
     def __init__(self, *args, **kwargs):
         if args and kwargs:
@@ -317,6 +329,32 @@ class CompositeType(object, metaclass=CompositeTypeMeta):
                 return False
         return True
 
+    @classmethod
+    def register_composite(cls, connection):
+        """
+        Register this CompositeType with Postgres.
+
+        If the CompositeType does not yet exist in the database, this will
+        fail.  Hopefully a migration will come along shortly and create the
+        type in the database. If `retry` is True, this CompositeType will try
+        to register itself again after the type is created.
+        """
+
+        LOGGER.debug("Registering composite type %s on connection %s",
+                     cls.__name__, connection)
+        cls.registered_connection = connection
+
+        with connection.temporary_connection() as cur:
+            # This is what to do when the type is coming out of the database
+            register_composite(cls._meta.db_type, cur, globally=True,
+                               factory=cls.Caster)
+            # This is what to do when the type is going in to the database
+            register_adapter(cls, QuotedCompositeType)
+
+    def __conform__(self, protocol):
+        if protocol is ISQLQuote:
+            return QuotedCompositeType(self)
+
     class Field(BaseField):
         """
         Placeholder for the field that will be produced for this type.
@@ -325,4 +363,9 @@ class CompositeType(object, metaclass=CompositeTypeMeta):
     class Operation(BaseOperation):
         """
         Placeholder for the DB operation that will be produced for this type.
+        """
+
+    class Caster(CompositeCaster):
+        """
+        Placeholder for the caster that will be produced for this type
         """

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -1,0 +1,80 @@
+"""
+Compatibility shims for running tests over multiple Django versions
+"""
+import django
+
+# Importing things in the 'wrong' version of Django makes pylint complain
+# pylint:disable=no-name-in-module,import-error
+# Importing things in an if: makes pylint complain
+# pylint:disable=wrong-import-position
+
+__all__ = ['ArrayField']
+
+if django.VERSION >= (1, 10):  # pylint:disable=too-complex
+    from django.contrib.postgres.fields.array import ArrayField
+else:
+    from django.core.exceptions import ValidationError
+    from django.contrib.postgres.fields.array import \
+        ArrayField as BaseArrayField
+
+    from postgres_composite_types.compat import prefix_validation_error
+
+    class ArrayField(BaseArrayField):
+        """
+        Django ArrayField has a bug with validation errors from the child
+        field.  A new ValidationError is constructed with the error from the
+        child, but the params dict is not included. If the child
+        ValidationError message contains format placeholders, the new
+        ValidationError throws an error when ever something tries to call `str`
+        or `repr` on it - which includes the templates when rendering errors
+        (which throws an error), and Djangos fancy debug error page. Fun times.
+
+        Similar to https://code.djangoproject.com/ticket/25841 but for the
+        ArrayField itself.
+
+        The buggy methods have been overridden below to fix the ValidationError
+        construction.
+        """
+        def validate(self, value, model_instance):
+            """
+            Validate that all the nested child fields pass validation
+            """
+            # pylint:disable=bad-super-call
+            # ArrayField.validate is broken, so skip over it and call the
+            # grandparent super method. The code below is a working replacement
+            # of ArrayField.validate
+            super(BaseArrayField, self).validate(value, model_instance)
+            # pylint:enable=bad-super-call
+            for i, part in enumerate(value):
+                try:
+                    self.base_field.validate(part, model_instance)
+                except ValidationError as err:
+                    raise prefix_validation_error(
+                        err, self.error_messages['item_invalid'],
+                        code='item_invalid',
+                        params={'nth': i})
+            if isinstance(self.base_field, BaseArrayField):
+                if len({len(i) for i in value}) > 1:
+                    raise ValidationError(
+                        self.error_messages['nested_array_mismatch'],
+                        code='nested_array_mismatch',
+                    )
+
+        def run_validators(self, value):
+            """
+            Run the validators for all the child fields
+            """
+            # pylint:disable=bad-super-call
+            # ArrayField.validate is broken, so skip over it and call the
+            # grandparent super method. The code below is a working replacement
+            # of ArrayField.validate
+            super(BaseArrayField, self).run_validators(value)
+            # pylint:enable=bad-super-call
+            for i, part in enumerate(value):
+                try:
+                    self.base_field.run_validators(part)
+                except ValidationError as err:
+                    raise prefix_validation_error(
+                        err, self.error_messages['item_invalid'],
+                        code='item_invalid',
+                        params={'nth': i})

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -5,7 +5,7 @@ Migration to create custom types
 
 from django.db import migrations
 
-from ..base import SimpleType
+from ..base import Box, Card, Point, SimpleType
 
 
 class Migration(migrations.Migration):
@@ -16,4 +16,7 @@ class Migration(migrations.Migration):
 
     operations = [
         SimpleType.Operation(),
+        Card.Operation(),
+        Point.Operation(),
+        Box.Operation(),
     ]

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -1,0 +1,84 @@
+"""
+Tests for composite fields in combination with other interesting fields.
+"""
+
+from django.test import TestCase
+
+from .base import Box, Card, Hand, Item, Point
+
+
+@Hand.fake_me
+class TestArrayFields(TestCase):
+    """
+    Test ArrayFields combined with CompositeType.Fields
+    """
+
+    def test_saving_and_loading_array_field(self):
+        """
+        Test saving and loading an ArrayField of a CompositeType
+        """
+        # Nice hand
+        hand = Hand(cards=[
+            Card('♡', '1'),
+            Card('♡', 'K'),
+            Card('♡', 'Q'),
+            Card('♡', 'J'),
+            Card('♡', '10'),
+        ])
+        hand.save()  # pylint:disable=no-member
+
+        hand = Hand.objects.get()
+        self.assertEqual(hand.cards, [
+            Card('♡', '1'),
+            Card('♡', 'K'),
+            Card('♡', 'Q'),
+            Card('♡', 'J'),
+            Card('♡', '10'),
+        ])
+
+    def test_querying_array_field_contains(self):
+        """
+        Test using some array__contains=[CompositeType]
+        """
+        hand = Hand(cards=[
+            Card('♡', '1'),
+            Card('♡', 'K'),
+            Card('♡', 'Q'),
+            Card('♡', 'J'),
+            Card('♡', '10'),
+        ])
+        hand.save()  # pylint:disable=no-member
+
+        queen_of_hearts = Card('♡', 'Q')
+        jack_of_spades = Card('♠', 'J')
+        self.assertTrue(
+            Hand.objects.filter(cards__contains=[queen_of_hearts]).exists())
+        self.assertFalse(
+            Hand.objects.filter(cards__contains=[jack_of_spades]).exists())
+
+
+@Item.fake_me
+class TestNestedCompositeTypes(TestCase):
+    """
+    Test CompositeTypes within CompositeTypes
+    """
+
+    def test_saving_and_loading_nested_composite_types(self):
+        """
+        Test saving and loading an Item with nested CompositeTypes
+        """
+        item = Item(name="table",
+                    bounding_box=Box(top_left=Point(x=1, y=1),
+                                     bottom_right=Point(x=4, y=2)))
+        item.save()  # pylint:disable=no-member
+
+        item = Item.objects.get()
+        self.assertEqual(item.name, "table")
+        self.assertEqual(item.bounding_box,
+                         Box(top_left=Point(x=1, y=1),
+                             bottom_right=Point(x=4, y=2)))
+
+        self.assertEqual(item.bounding_box.bottom_left,
+                         Point(x=1, y=2))
+        self.assertEqual(item.bounding_box.top_right,
+                         Point(x=4, y=1))


### PR DESCRIPTION
Instead of relying on Django and its `get_db_value`/`from_db_value`, the type is registered more deeply with Postgres. This allows the type to be used in ArrayFields and other places where typecasting is required.