### PR TITLE
Allow use of reserved keywords as field names.

### DIFF
--- a/postgres_composite_types/__init__.py
+++ b/postgres_composite_types/__init__.py
@@ -145,13 +145,14 @@ class BaseOperation(migrations.operations.base.Operation):
                           from_state, to_state):
 
         fields = [
-            '%s %s' % (name, field.db_type(schema_editor.connection))
+            '%s %s' % (schema_editor.quote_name(name),
+                       field.db_type(schema_editor.connection))
             for name, field in self.Meta.fields
         ]
 
         schema_editor.execute(' '.join((
             "CREATE TYPE",
-            self.Meta.db_type,
+            schema_editor.quote_name(self.Meta.db_type),
             "AS (%s)" % ', '.join(fields),
         )))
 
@@ -162,7 +163,8 @@ class BaseOperation(migrations.operations.base.Operation):
 
     def database_backwards(self, app_label, schema_editor,
                            from_state, to_state):
-        schema_editor.execute('DROP TYPE %s' % self.Meta.db_type)
+        type_name = schema_editor.quote_name(self.Meta.db_type)
+        schema_editor.execute('DROP TYPE %s' % type_name)
 
 
 class BaseCaster(CompositeCaster):

--- a/tests/base.py
+++ b/tests/base.py
@@ -93,3 +93,18 @@ class Item(FakeModel):
     """An item that exists somewhere on a cartesian plane."""
     name = models.CharField(max_length=20)
     bounding_box = Box.Field()
+
+
+class DateRange(CompositeType):
+    """A date range with start and end."""
+    class Meta:
+        db_type = 'test_date_range'
+
+    start = models.DateTimeField()
+    end = models.DateTimeField()   # uses reserved keyword
+
+
+class NamedDateRange(FakeModel):
+    """A date-range with a name"""
+    name = models.TextField()
+    date_range = DateRange.Field()

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -5,7 +5,7 @@ Migration to create custom types
 
 from django.db import migrations
 
-from ..base import Box, Card, OptionalBits, Point, SimpleType
+from ..base import Box, Card, DateRange, OptionalBits, Point, SimpleType
 
 
 class Migration(migrations.Migration):
@@ -20,4 +20,5 @@ class Migration(migrations.Migration):
         Card.Operation(),
         Point.Operation(),
         Box.Operation(),
+        DateRange.Operation(),
     ]


### PR DESCRIPTION
Quote field names when creating composite type to allow for usage of keywords that are reserved in PostgreSQL.

The tests for saving/loading aren't strictly necessary with the current implementation, but it's a good sanity check.