### PR TITLE
Fix issue #12: Migrations can be generated for nested cases

### DIFF
--- a/postgres_composite_types/__init__.py
+++ b/postgres_composite_types/__init__.py
@@ -35,6 +35,7 @@ Takes inspiration from:
 """
 
 import logging
+import sys
 from collections import OrderedDict
 
 from django.db import migrations, models
@@ -176,6 +177,12 @@ class BaseCaster(CompositeCaster):
         return self.Meta.model(*values)
 
 
+def _add_class_to_module(cls, module_name):
+    cls.__module__ = module_name
+    module = sys.modules[module_name]
+    setattr(module, cls.__name__, cls)
+
+
 class CompositeTypeMeta(type):
     """Metaclass for Type."""
 
@@ -222,6 +229,10 @@ class CompositeTypeMeta(type):
         attrs['Field'] = type('%sField' % name,
                               (BaseField,),
                               {'Meta': meta_obj})
+
+        # add field class to the module in which the composite type class lives
+        # this is required for migrations to work
+        _add_class_to_module(attrs['Field'], attrs['__module__'])
 
         # create the database operation for this type
         attrs['Operation'] = type('Create%sType' % name,

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -63,8 +63,8 @@ class TestArrayFields(TestCase):
         text, _ = MigrationWriter.serialize(field)
         # build the expected full path of the nested composite type class
         models_module = Hand.__module__
-        base_field_cls = field.base_field.__class__.__name__
-        expected_path = '.'.join((models_module, base_field_cls))
+        composite_field_cls = field.base_field.__class__.__name__
+        expected_path = '.'.join((models_module, composite_field_cls))
         # check that the expected path is the one used by deconstruct
         expected_deconstruction = 'base_field={}()'.format(expected_path)
         self.assertIn(expected_deconstruction, text)


### PR DESCRIPTION
I tried a couple of different approaches to start with, and although this isn't the most beautiful solution, I'm pretty sure it's the only one that will work with the current architecture.

Modifying the `deconstruct()` method for the field to point to `<composite type>.Field()` doesn't work as Django insists on adding an `import <app name>.models.<composite type>.Field` statement to the migration, which obviously fails since the composite type isn't a module. This seems to be a broader problem with Django and migrations of nested classes.

The solution is to insert dynamically created field class into the `models` module of the app that has declared the composite type, to allow for migrations to be generated and run correctly when nested.

I've added a unit test for generating the migrations for now, and it's working for me in my project, but maybe there should be another test that somehow checks the migration will run?