### PR TITLE
Use custom type descriptors registered by model fields

### DIFF
--- a/postgres_composite_types/__init__.py
+++ b/postgres_composite_types/__init__.py
@@ -266,19 +266,26 @@ class CompositeTypeMeta(type):
                                    dispatch_uid=cls._meta.db_type)
 
     def _capture_descriptors(cls):
-        """ Work around for not being able to call contribute_to_class."""
+        """Work around for not being able to call contribute_to_class.
 
-        # Too much to fake to call contribute_to_class directly, but we still
-        # want fields to be able to set custom type descriptors.
-        # So we fake a model instead, and find any descriptors on that
+        Too much code to fake in our meta objects etc to be able to call
+        contribute_to_class directly, but we still want fields to be able
+        to set custom type descriptors. So we fake a model instead, with the
+        same fields as the composite type, and extract any custom descriptors
+        on that.
+        """
+
         attrs = {field_name: field for field_name, field in cls._meta.fields}
 
+        # we need to build a unique app label and model name combination for
+        # every composite type so django doesn't complain about model reloads
         class Meta:
             app_label = cls.__module__
-
         attrs['__module__'] = cls.__module__
         attrs['Meta'] = Meta
-        fake_model = type(cls.__name__ + 'FakeModel', (models.Model,), attrs)
+        model_name = '_Fake{}Model'.format(cls.__name__)
+
+        fake_model = type(model_name, (models.Model,), attrs)
         for field_name, _ in cls._meta.fields:
             # default None is for django 1.9
             attr = getattr(fake_model, field_name, None)

--- a/tests/base.py
+++ b/tests/base.py
@@ -5,6 +5,7 @@ from django_fake_model.models import FakeModel
 from postgres_composite_types import CompositeType
 
 from .compat import ArrayField
+from .fields import TriplingIntegerField
 
 
 # pylint:disable=no-member
@@ -108,30 +109,6 @@ class NamedDateRange(FakeModel):
     """A date-range with a name"""
     name = models.TextField()
     date_range = DateRange.Field()
-
-
-class TripleOnAssignDescriptor:
-    """Multiply by 3 on assign"""
-    def __init__(self, field):
-        self.field = field
-
-    def __get__(self, instance, owner=None):
-        if instance is None:
-            return self
-        return instance.__dict__[self.field.name]
-
-    def __set__(self, instance, value):
-        # Allow NULL
-        if value is not None:
-            value *= 3
-        instance.__dict__[self.field.name] = value
-
-
-class TriplingIntegerField(models.IntegerField):
-    """Field that triples assigned value"""
-    def contribute_to_class(self, cls, name, **kwargs):
-        super().contribute_to_class(cls, name, **kwargs)
-        setattr(cls, self.name, TripleOnAssignDescriptor(self))
 
 
 class DescriptorType(CompositeType):

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -1,0 +1,29 @@
+"""
+Custom fields for the tests.
+"""
+
+from django.db import models
+
+
+class TripleOnAssignDescriptor:
+    """A descriptor that multiplies the assigned value by 3."""
+    def __init__(self, field):
+        self.field = field
+
+    def __get__(self, instance, owner=None):
+        if instance is None:
+            return self
+        return instance.__dict__[self.field.name]
+
+    def __set__(self, instance, value):
+        # Allow NULL
+        if value is not None:
+            value *= 3
+        instance.__dict__[self.field.name] = value
+
+
+class TriplingIntegerField(models.IntegerField):
+    """Field that triples assigned value."""
+    def contribute_to_class(self, cls, name, **kwargs):
+        super().contribute_to_class(cls, name, **kwargs)
+        setattr(cls, self.name, TripleOnAssignDescriptor(self))

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -5,7 +5,8 @@ Migration to create custom types
 
 from django.db import migrations
 
-from ..base import Box, Card, DateRange, OptionalBits, Point, SimpleType
+from ..base import (
+    Box, Card, DateRange, DescriptorType, OptionalBits, Point, SimpleType)
 
 
 class Migration(migrations.Migration):
@@ -21,4 +22,5 @@ class Migration(migrations.Migration):
         Point.Operation(),
         Box.Operation(),
         DateRange.Operation(),
+        DescriptorType.Operation(),
     ]

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -6,7 +6,13 @@ Migration to create custom types
 from django.db import migrations
 
 from ..base import (
-    Box, Card, DateRange, DescriptorType, OptionalBits, Point, SimpleType)
+    Box,
+    Card,
+    DateRange,
+    DescriptorType,
+    OptionalBits,
+    Point,
+    SimpleType)
 
 
 class Migration(migrations.Migration):

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -5,7 +5,8 @@ Tests for composite fields in combination with other interesting fields.
 from django.db.migrations.writer import MigrationWriter
 from django.test import TestCase
 
-from .base import Box, Card, Hand, Item, Point
+from .base import (
+    Box, Card, DescriptorModel, DescriptorType, Hand, Item, Point)
 
 
 @Hand.fake_me
@@ -95,3 +96,20 @@ class TestNestedCompositeTypes(TestCase):
                          Point(x=1, y=2))
         self.assertEqual(item.bounding_box.top_right,
                          Point(x=4, y=1))
+
+
+class TestCustomDescriptors(TestCase):
+    """
+    Test CompositeTypes with Fields with custom descriptors.
+    """
+
+    def test_create(self):
+        """Test descriptor used on creation"""
+        model = DescriptorModel(field=DescriptorType(value=1))
+        self.assertEqual(model.field.value, 3)
+
+    def test_set(self):
+        """Test descriptor used on assign"""
+        model = DescriptorModel(field=DescriptorType(value=0))
+        model.field.value = 14
+        self.assertEqual(model.field.value, 42)

--- a/tests/test_more.py
+++ b/tests/test_more.py
@@ -6,7 +6,13 @@ from django.db.migrations.writer import MigrationWriter
 from django.test import TestCase
 
 from .base import (
-    Box, Card, DescriptorModel, DescriptorType, Hand, Item, Point)
+    Box,
+    Card,
+    DescriptorModel,
+    DescriptorType,
+    Hand,
+    Item,
+    Point)
 
 
 @Hand.fake_me


### PR DESCRIPTION
Came across this when using [django-enumfields](https://github.com/hzdg/django-enumfields), which registers a custom type descriptor. This change preserves that behaviour for `CompositeType`. This should also work for the standard `FileField`.

The implementation fakes a model based on the fields declared in the `CompositeType` subclass to get type descriptors (if any) out of the fields. This ended up being much cleaner and simpler than trying to fake what's required to call `Field.contribute_to_class` with a `CompositeType` as the class.

