### PR TITLE
Respect custom Field base classes on CompositeTypes

### DIFF
--- a/postgres_composite_types/__init__.py
+++ b/postgres_composite_types/__init__.py
@@ -273,8 +273,9 @@ class CompositeTypeMeta(type):
         meta_obj.fields = fields
 
         # create the field for this Type
+        field_base_class = attrs['Field'] if 'Field' in attrs else BaseField
         attrs['Field'] = type('%sField' % name,
-                              (BaseField,),
+                              (field_base_class,),
                               {'Meta': meta_obj})
 
         # add field class to the module in which the composite type class lives

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -12,7 +12,8 @@ from ..models import (
     DescriptorType,
     OptionalBits,
     Point,
-    SimpleType)
+    SimpleType,
+    CustomFieldClassType)
 
 
 class Migration(migrations.Migration):
@@ -29,4 +30,5 @@ class Migration(migrations.Migration):
         Box.Operation(),
         DateRange.Operation(),
         DescriptorType.Operation(),
+        CustomFieldClassType.Operation(),
     ]

--- a/tests/migrations/0002_models.py
+++ b/tests/migrations/0002_models.py
@@ -59,4 +59,11 @@ class Migration(migrations.Migration):
                 ('test_field', tests.models.SimpleTypeField()),
             ],
         ),
+        migrations.CreateModel(
+            name='CustomFieldClassModel',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('field', tests.models.CustomFieldClassTypeField(blank=True, null=True)),
+            ]
+        )
     ]

--- a/tests/models.py
+++ b/tests/models.py
@@ -2,7 +2,7 @@
 from django.contrib.postgres.fields.array import ArrayField
 from django.db import models
 
-from postgres_composite_types import CompositeType
+from postgres_composite_types import BaseField, CompositeType
 
 from .fields import TriplingIntegerField
 
@@ -117,3 +117,21 @@ class DescriptorType(CompositeType):
 class DescriptorModel(models.Model):
     """Has a composite type with a field implementing a custom descriptor"""
     field = DescriptorType.Field()
+
+
+class CustomFieldClassType(CompositeType):
+    """Has a custom Field class implementation"""
+    class Meta:
+        db_type = 'test_custom_field_class'
+
+    value = models.IntegerField()
+
+    class Field(BaseField):
+        def test_method(self):
+            """Test method to be present on field instance"""
+            return 42
+
+
+class CustomFieldClassModel(models.Model):
+    """Uses the custom field with a custom field class"""
+    field = CustomFieldClassType.Field(null=True, blank=True)

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -14,8 +14,9 @@ from psycopg2.extensions import adapt
 from postgres_composite_types import composite_type_created
 
 from .models import (
-    Box, DateRange, Item, NamedDateRange, OptionalBits, OptionalModel, Point,
-    SimpleModel, SimpleType)
+    Box, CustomFieldClassModel, CustomFieldClassType, DateRange, Item,
+    NamedDateRange, OptionalBits, OptionalModel, Point, SimpleModel,
+    SimpleType)
 
 
 class TestMigrations(TransactionTestCase):
@@ -232,3 +233,17 @@ class TestOptionalFields(TestCase):
         self.assertIsNotNone(model.optional_field)
         self.assertEqual(model.optional_field, OptionalBits(
             required='foo', optional='bar'))
+
+
+class TestCustomBaseClasses(TestCase):
+    """
+    Test overriding placeholder classes in CompositeType
+    """
+    def test_custom_field_class(self):
+        model = CustomFieldClassModel(field=None)
+        model.save()
+
+        model = CustomFieldClassModel.objects.get(id=1)
+        field = model._meta.get_field('field')
+        val = field.test_method()
+        self.assertEqual(val, 42)


### PR DESCRIPTION
Motivation for this PR: 
I needed to be able to provide custom `to_python`, `get_prep_value` methods on the generated field class. Currently this is not possible as `CompositeTypeMeta.__new__` will only use `BaseField` as a base to generating a field class.

Changes in this PR:
When a class named `Field` is supplied on a subclass of `CompositeType` we respect this and use it as a base class instead of the placeholder (`CompositeType.Field`) class.