### PR TITLE
Fix rendering of null values in widget

### DIFF
--- a/postgres_composite_types/__init__.py
+++ b/postgres_composite_types/__init__.py
@@ -55,7 +55,7 @@ LOGGER = logging.getLogger(__name__)
 __all__ = ['CompositeType']
 
 
-class QuotedCompositeType(object):
+class QuotedCompositeType():
     """
     A wrapper for CompositeTypes that knows how to convert itself into a safe
     postgres representation. Created from CompositeType.__conform__
@@ -234,7 +234,7 @@ class CompositeTypeMeta(type):
     """Metaclass for Type."""
 
     @classmethod
-    def __prepare__(mcs, name, bases):
+    def __prepare__(cls, name, bases):
         """
         Guarantee the ordering of the declared attrs.
 
@@ -243,10 +243,10 @@ class CompositeTypeMeta(type):
         """
         return OrderedDict()
 
-    def __new__(mcs, name, bases, attrs):
+    def __new__(cls, name, bases, attrs):
         # Only apply the metaclass to our subclasses
         if name == 'CompositeType':
-            return super().__new__(mcs, name, bases, attrs)
+            return super().__new__(cls, name, bases, attrs)
 
         # retrieve any fields from our declaration
         fields = []
@@ -291,7 +291,7 @@ class CompositeTypeMeta(type):
                                (BaseCaster,),
                                {'Meta': meta_obj})
 
-        new_cls = super().__new__(mcs, name, bases, attrs)
+        new_cls = super().__new__(cls, name, bases, attrs)
         new_cls._meta = meta_obj
 
         meta_obj.model = new_cls
@@ -365,7 +365,7 @@ composite_type_created = Signal()
 # pylint:enable=invalid-name
 
 
-class CompositeType(object, metaclass=CompositeTypeMeta):
+class CompositeType(metaclass=CompositeTypeMeta):
     """
     A new composite type stored in Postgres.
     """

--- a/postgres_composite_types/forms.py
+++ b/postgres_composite_types/forms.py
@@ -117,6 +117,9 @@ class CompositeTypeField(forms.Field):
         if isinstance(value, CompositeType):
             return value.__to_dict__()
 
+        if value is None:
+            return {}
+
         return value
 
     def validate(self, value):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -109,6 +109,19 @@ class TestField(SimpleTestCase):
             """,
             str(form['simple_field']))
 
+    def test_null_initial_data(self):
+        """
+        Check that forms with null initial data render with the fields.
+        """
+        form = self.SimpleForm(initial={'simple_field': None})
+
+        self.assertHTMLContains(
+            """
+            <input type="number" name="simple_field-a" placeholder="A number"
+            required id="id_simple_field-a" />
+            """,
+            str(form['simple_field']))
+
     # pylint:disable=invalid-name
     def assertHTMLContains(self, text, content, count=None, msg=None):
         """


### PR DESCRIPTION
I've run into this error when trying to render null composite fields in the admin:
```py
Traceback (most recent call last):
  File "/projects/django-postgres-composite-types/tests/test_forms.py", line 123, in test_null_initial_data
    str(form['simple_field']))
  File "/projects/django-postgres-composite-types/.tox/py36-dj1.11/lib/python3.6/site-packages/django/utils/html.py", line 394, in <lambda>
    klass.__str__ = lambda self: mark_safe(klass_str(self))
  File "/projects/django-postgres-composite-types/.tox/py36-dj1.11/lib/python3.6/site-packages/django/forms/boundfield.py", line 41, in __str__
    return self.as_widget()
  File "/projects/django-postgres-composite-types/.tox/py36-dj1.11/lib/python3.6/site-packages/django/forms/boundfield.py", line 127, in as_widget
    **kwargs
  File "/projects/django-postgres-composite-types/.tox/py36-dj1.11/lib/python3.6/site-packages/django/forms/widgets.py", line 220, in render
    context = self.get_context(name, value, attrs)
  File "/projects/django-postgres-composite-types/postgres_composite_types/forms.py", line 204, in get_context
    value.get(subname),
AttributeError: 'NoneType' object has no attribute 'get'
```

I've added a simple fix to return an empty dict when the value of the field is null in the `CompositeTypeField` to prevent the widget from breaking.