### PR TITLE
Implement composite member lookup

### DIFF
--- a/postgres_composite_types/composite_type.py
+++ b/postgres_composite_types/composite_type.py
@@ -87,6 +87,19 @@ class CompositeTypeMeta(type):
         new_cls = super().__new__(cls, name, bases, attrs)
         new_cls._meta = meta_obj
 
+        for _, field in new_cls._meta.fields:
+            new_cls.Field.register_lookup(
+                type(
+                    f"{name}{field.attname}Lookup",
+                    (models.Transform,),
+                    {
+                        "lookup_name": field.attname,
+                        "arity": 1,
+                        "template": f'(%(expressions)s)."{field.column}"',
+                    },
+                )
+            )
+
         meta_obj.model = new_cls
 
         return new_cls

--- a/postgres_composite_types/operations.py
+++ b/postgres_composite_types/operations.py
@@ -13,8 +13,7 @@ def sql_field_definition(field_name, field, schema_editor):
 
 def sql_create_type(type_name, fields, schema_editor):
     fields_list = ", ".join(
-        sql_field_definition(field_name, field, schema_editor)
-        for field_name, field in fields
+        sql_field_definition(field.column, field, schema_editor) for _, field in fields
     )
     quoted_name = schema_editor.quote_name(type_name)
     return f"CREATE TYPE {quoted_name} AS ({fields_list})"

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -11,6 +11,7 @@ from ..models import (
     DescriptorType,
     OptionalBits,
     Point,
+    RenamedMemberType,
     SimpleType,
 )
 
@@ -28,4 +29,5 @@ class Migration(migrations.Migration):
         Box.Operation(),
         DateRange.Operation(),
         DescriptorType.Operation(),
+        RenamedMemberType.Operation(),
     ]

--- a/tests/migrations/0002_models.py
+++ b/tests/migrations/0002_models.py
@@ -7,7 +7,6 @@ import tests.models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [
@@ -113,6 +112,12 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("test_field", tests.models.SimpleTypeField()),
+            ],
+        ),
+        migrations.CreateModel(
+            name="RenamedMemberModel",
+            fields=[
+                ("field", tests.models.RenamedMemberTypeField()),
             ],
         ),
     ]

--- a/tests/models.py
+++ b/tests/models.py
@@ -123,3 +123,19 @@ class DescriptorModel(models.Model):
     """Has a composite type with a field implementing a custom descriptor"""
 
     field = DescriptorType.Field()
+
+
+class RenamedMemberType(CompositeType):
+    """Has a field with a different name in ORM vs db"""
+
+    class Meta:
+        db_type = "test_renamed_member"
+
+    orm_name = models.CharField(db_column="db_name", max_length=32)
+    other = models.BooleanField(default=False)
+
+
+class RenamedMemberModel(models.Model):
+    """Has a composite type with a member attr name that differs from the column name"""
+
+    field = RenamedMemberType.Field()


### PR DESCRIPTION
Closes #9 

Also introduces support for a differing `db_column`, since I covered that in lookup test cases only to realise it actually didn't work at all 🙂.